### PR TITLE
Console is required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "doctrine/cache"       : "~1.0",
         "monolog/monolog"      : "~1.3",
         "phpexiftool/exiftool" : "9.15",
-        "symfony/process"      : "~2.0"
+        "symfony/process"      : "~2.0",
+        "symfony/console"      : "~2.0"
     },
     "suggest": {
         "jms/serializer"       : "To serialize tags",
@@ -26,7 +27,6 @@
     "require-dev": {
         "symfony/css-selector" : "~2.0",
         "symfony/finder"       : "~2.0",
-        "symfony/console"      : "~2.0",
         "symfony/dom-crawler"  : "~2.0",
         "symfony/yaml"         : "~2.0",
         "jms/serializer"       : "~0.10",


### PR DESCRIPTION
It seems the Command class is required to get the project working.

Unless this is because I am missing drivers this should be added to the requirements.
